### PR TITLE
KAFKA-2979: only set client auth if the authoriser is specified (fixe…

### DIFF
--- a/tests/kafkatest/services/kafka/templates/kafka.properties
+++ b/tests/kafkatest/services/kafka/templates/kafka.properties
@@ -52,7 +52,6 @@ quota.consumer.bytes.per.second.overrides={{ quota_config.quota_consumer_bytes_p
 
 security.inter.broker.protocol={{ interbroker_security_protocol }}
 
-ssl.client.auth=required
 ssl.keystore.location=/mnt/security/test.keystore.jks
 ssl.keystore.password=test-ks-passwd
 ssl.key.password=test-key-passwd
@@ -63,6 +62,7 @@ ssl.truststore.type=JKS
 sasl.mechanism={{ sasl_mechanism }}
 sasl.kerberos.service.name=kafka
 {% if authorizer_class_name is defined %}
+ssl.client.auth=required
 authorizer.class.name={{ authorizer_class_name }}
 {% endif %}
 


### PR DESCRIPTION
…s brake to log4j appender test)
